### PR TITLE
Parse CallExpressions

### DIFF
--- a/packages/interpreter/src/ast/index.ts
+++ b/packages/interpreter/src/ast/index.ts
@@ -1,5 +1,8 @@
 export { default as BooleanLiteral } from './nodes/boolean-literal';
+export { default as BlockStatement } from './nodes/block-statement';
+export { default as CallExpression } from './nodes/call-expression';
 export { default as ExpressionStatement } from './nodes/expression';
+export { default as FunctionLiteral } from './nodes/function-literal';
 export { default as Identifier } from './nodes/identifier';
 export { default as IfExpression } from './nodes/if-expression';
 export { default as InfixExpression } from './nodes/infix-expression';
@@ -9,15 +12,15 @@ export { default as PrefixExpression } from './nodes/prefix-expression';
 export { default as Program } from './nodes/program';
 export { default as ReturnStatement } from './nodes/return';
 
-export interface Node {
+export interface ASTNode {
   tokenLiteral(): string;
   toString(): string;
 }
 
-export interface Statement extends Node {
+export interface Statement extends ASTNode {
   statementNode(): unknown;
 }
 
-export interface Expression extends Node {
+export interface Expression extends ASTNode {
   expressionNode(): unknown;
 }

--- a/packages/interpreter/src/ast/nodes/call-expression.ts
+++ b/packages/interpreter/src/ast/nodes/call-expression.ts
@@ -1,0 +1,20 @@
+import { LeftParenToken } from '../../token/';
+import { Expression } from '../../ast/';
+
+export default class CallExpression implements Expression {
+  constructor(
+    public token: LeftParenToken,
+    public fn: Expression,
+    public args: Expression[] | null
+  ) {}
+
+  expressionNode() {}
+  tokenLiteral() {
+    return this.token.literal;
+  }
+  toString() {
+    return `${this.fn?.toString()}(${this.args
+      ?.map(arg => arg.toString())
+      .join(', ')})`;
+  }
+}

--- a/packages/interpreter/src/ast/nodes/expression.ts
+++ b/packages/interpreter/src/ast/nodes/expression.ts
@@ -2,8 +2,7 @@ import { Token } from '../../token/';
 import { Expression, Statement } from '../../ast/';
 
 export default class ExpressionStatement implements Statement {
-  public expression?: Expression;
-  constructor(public token: Token) {}
+  constructor(public token: Token, public expression: Expression | null) {}
 
   statementNode() {}
   tokenLiteral() {

--- a/packages/interpreter/src/ast/nodes/function-literal.ts
+++ b/packages/interpreter/src/ast/nodes/function-literal.ts
@@ -1,10 +1,9 @@
 import { FunctionLiteralToken } from '../../token/';
-import { Identifier, Expression } from '../../ast/';
-import BlockStatement from './block-statement';
+import { BlockStatement, Identifier, Expression } from '../../ast/';
 
 export default class FunctionLiteral implements Expression {
-  public parameters?: Identifier[];
-  public body?: BlockStatement;
+  public parameters: Identifier[] | null = null;
+  public body: BlockStatement | null = null;
   constructor(public token: FunctionLiteralToken) {}
 
   expressionNode() {}

--- a/packages/interpreter/src/ast/nodes/if-expression.ts
+++ b/packages/interpreter/src/ast/nodes/if-expression.ts
@@ -1,11 +1,10 @@
 import { IfExpressionToken } from '../../token/';
-import { Expression } from '../../ast/';
-import BlockStatement from './block-statement';
+import { Expression, BlockStatement } from '../../ast/';
 
 export default class IfExpression implements Expression {
-  public condition?: Expression;
-  public consequence?: BlockStatement;
-  public alternative?: BlockStatement;
+  public condition: Expression | null = null;
+  public consequence: BlockStatement | null = null;
+  public alternative: BlockStatement | null = null;
   constructor(public token: IfExpressionToken) {}
 
   expressionNode() {}

--- a/packages/interpreter/src/ast/nodes/infix-expression.ts
+++ b/packages/interpreter/src/ast/nodes/infix-expression.ts
@@ -2,9 +2,12 @@ import { Token } from '../../token/';
 import { Expression } from '../../ast/';
 
 export default class InfixExpression implements Expression {
-  public left?: Expression;
-  public right?: Expression;
-  constructor(public token: Token, public operator: string) {}
+  public right: Expression | null = null;
+  constructor(
+    public token: Token,
+    public operator: string,
+    public left: Expression | null = null
+  ) {}
 
   expressionNode() {}
   tokenLiteral() {

--- a/packages/interpreter/src/ast/nodes/let.ts
+++ b/packages/interpreter/src/ast/nodes/let.ts
@@ -2,8 +2,8 @@ import { LetStatementToken } from '../../token/';
 import { Identifier, Expression, Statement } from '../../ast/';
 
 export default class LetStatement implements Statement {
-  public name?: Identifier;
-  public value?: Expression;
+  public name: Identifier | null = null;
+  public value: Expression | null = null;
   constructor(public token: LetStatementToken) {}
 
   statementNode() {}

--- a/packages/interpreter/src/ast/nodes/prefix-expression.ts
+++ b/packages/interpreter/src/ast/nodes/prefix-expression.ts
@@ -2,7 +2,7 @@ import { Token } from '../../token/';
 import { Expression } from '../../ast/';
 
 export default class PrefixExpression implements Expression {
-  public right?: Expression;
+  public right: Expression | null = null;
   constructor(public token: Token, public operator: string) {}
 
   expressionNode() {}

--- a/packages/interpreter/src/ast/nodes/program.ts
+++ b/packages/interpreter/src/ast/nodes/program.ts
@@ -1,6 +1,6 @@
-import { Statement, Node } from '../../ast/';
+import { Statement, ASTNode } from '../../ast/';
 
-export default class Program implements Node {
+export default class Program implements ASTNode {
   public statements: Statement[] = [];
 
   tokenLiteral(): string {

--- a/packages/interpreter/src/ast/nodes/return.ts
+++ b/packages/interpreter/src/ast/nodes/return.ts
@@ -2,7 +2,7 @@ import { ReturnStatementToken } from '../../token/';
 import { Expression, Statement } from '../../ast/';
 
 export default class ReturnStatement implements Statement {
-  public returnValue?: Expression;
+  public returnValue: Expression | null = null;
   constructor(public token: ReturnStatementToken) {}
 
   statementNode() {}

--- a/packages/interpreter/src/parser/infix/parse-call-expression.ts
+++ b/packages/interpreter/src/parser/infix/parse-call-expression.ts
@@ -1,0 +1,12 @@
+import Parser from '..';
+import { CallExpression, Expression } from '../../ast';
+import assertTokenType from '../../utils/assert-token-type';
+import { TokenType } from '../../token';
+
+export default function parseCallExpression(
+  this: Parser,
+  fn: Expression
+): Expression {
+  assertTokenType(this.currToken, TokenType.LPAREN);
+  return new CallExpression(this.currToken, fn, this.parseCallArguments());
+}

--- a/packages/interpreter/src/parser/infix/parse-infix-expression.ts
+++ b/packages/interpreter/src/parser/infix/parse-infix-expression.ts
@@ -2,21 +2,14 @@ import Parser from '..';
 import { Expression, InfixExpression } from '../../ast';
 
 export default function parseInfixExpression(this: Parser, left: Expression): Expression {
-  if (this.currToken === undefined) {
-    throw new TypeError(`Was expecting ${this.currToken} to be defined`);
-  }
-  const infixExpression = new InfixExpression(
+  const expr = new InfixExpression(
     this.currToken,
-    this.currToken.literal
+    this.currToken.literal,
+    left
   );
-  infixExpression.left = left;
   const precedence = this.currPrecedence();
   this.nextToken();
 
-  const rightExpression = this.parseExpression(precedence);
-  if (rightExpression) {
-    infixExpression.right = rightExpression;
-  }
-
-  return infixExpression;
+  expr.right = this.parseExpression(precedence);
+  return expr;
 }

--- a/packages/interpreter/src/parser/prefix/parse-boolean.ts
+++ b/packages/interpreter/src/parser/prefix/parse-boolean.ts
@@ -1,12 +1,9 @@
 import Parser from '..';
 import { Expression, BooleanLiteral } from '../../ast';
-import { assertTokenType } from '../../utils/assertions';
+import assertTokenType from '../../utils/assert-token-type';
 import { TokenType } from '../../token';
 
 export default function parseBoolean(this: Parser): Expression {
-  if (this.currToken === undefined) {
-    throw new TypeError(`Was expecting ${this.currToken} to be defined`);
-  }
   assertTokenType(this.currToken, TokenType.TRUE, TokenType.FALSE)
   return new BooleanLiteral(this.currToken, this.currTokenIs(TokenType.TRUE));
 }

--- a/packages/interpreter/src/parser/prefix/parse-function-literal.ts
+++ b/packages/interpreter/src/parser/prefix/parse-function-literal.ts
@@ -1,13 +1,9 @@
 import Parser from '..';
-import { Expression } from '../../ast';
+import { Expression, FunctionLiteral } from '../../ast';
 import { TokenType } from '../../token';
-import FunctionLiteral from '../../ast/nodes/function-literal';
-import { assertTokenType } from '../../utils/assertions';
+import assertTokenType from '../../utils/assert-token-type';
 
 export default function parseFunctionLiteral(this: Parser): Expression | null {
-  if (this.currToken === undefined) {
-    throw new TypeError(`Was expecting ${this.currToken} to be defined`);
-  }
   assertTokenType(this.currToken, TokenType.FUNCTION);
   const expr = new FunctionLiteral(this.currToken);
 
@@ -15,19 +11,12 @@ export default function parseFunctionLiteral(this: Parser): Expression | null {
     return null;
   }
 
-  const parameters = this.parseFunctionParameters();
-  if (parameters) {
-    expr.parameters = parameters;
-  }
+  expr.parameters = this.parseFunctionParameters();
 
   if (!this.expectPeek(TokenType.LBRACE)) {
     return null;
   }
 
-  const body = this.parseBlockStatement();
-  if (body) {
-    expr.body = body;
-  }
-
+  expr.body = this.parseBlockStatement();
   return expr;
 }

--- a/packages/interpreter/src/parser/prefix/parse-identifier.ts
+++ b/packages/interpreter/src/parser/prefix/parse-identifier.ts
@@ -1,12 +1,9 @@
 import Parser from '..';
 import { Expression, Identifier } from '../../ast';
-import { assertTokenType } from '../../utils/assertions';
 import { TokenType } from '../../token';
+import assertTokenType from '../../utils/assert-token-type';
 
 export default function parseIdentifier(this: Parser): Expression {
-  if (this.currToken === undefined) {
-    throw new TypeError(`Was expecting ${this.currToken} to be defined`);
-  }
   assertTokenType(this.currToken, TokenType.IDENT);
   return new Identifier(this.currToken, this.currToken.literal);
 }

--- a/packages/interpreter/src/parser/prefix/parse-if-expression.ts
+++ b/packages/interpreter/src/parser/prefix/parse-if-expression.ts
@@ -1,12 +1,9 @@
 import Parser, { PrecedenceOrder } from '..';
 import { IfExpression, Expression } from '../../ast';
-import { assertTokenType } from '../../utils/assertions';
 import { TokenType } from '../../token';
+import assertTokenType from '../../utils/assert-token-type';
 
 export default function parseIfExpression(this: Parser): Expression | null {
-  if (this.currToken === undefined) {
-    throw new TypeError(`Was expecting ${this.currToken} to be defined`);
-  }
   assertTokenType(this.currToken, TokenType.IF);
   const expr = new IfExpression(this.currToken);
 
@@ -15,10 +12,7 @@ export default function parseIfExpression(this: Parser): Expression | null {
   }
   this.nextToken();
 
-  const condition = this.parseExpression(PrecedenceOrder.LOWEST);
-  if (condition) {
-    expr.condition = condition;
-  }
+  expr.condition = this.parseExpression(PrecedenceOrder.LOWEST);
 
   if (!this.expectPeek(TokenType.RPAREN)) {
     return null;
@@ -28,10 +22,7 @@ export default function parseIfExpression(this: Parser): Expression | null {
     return null;
   }
 
-  const consequence = this.parseBlockStatement();
-  if (consequence) {
-    expr.consequence = consequence;
-  }
+  expr.consequence = this.parseBlockStatement();
 
   if (this.peekTokenIs(TokenType.ELSE)) {
     this.nextToken();
@@ -40,10 +31,7 @@ export default function parseIfExpression(this: Parser): Expression | null {
       return null;
     }
 
-    const alternative = this.parseBlockStatement();
-    if (alternative) {
-      expr.alternative = alternative;
-    }
+    expr.alternative = this.parseBlockStatement();
   }
 
   return expr;

--- a/packages/interpreter/src/parser/prefix/parse-integer-literal.ts
+++ b/packages/interpreter/src/parser/prefix/parse-integer-literal.ts
@@ -1,12 +1,9 @@
 import Parser from '..';
 import { Expression, IntegerLiteral } from '../../ast';
-import { assertTokenType } from '../../utils/assertions';
 import { TokenType } from '../../token';
+import assertTokenType from '../../utils/assert-token-type';
 
 export default function parseIntegerLiteral(this: Parser): Expression {
-  if (this.currToken === undefined) {
-    throw new TypeError(`Was expecting ${this.currToken} to be defined`);
-  }
   assertTokenType(this.currToken, TokenType.INT);
   return new IntegerLiteral(this.currToken, parseInt(this.currToken.literal));
 }

--- a/packages/interpreter/src/parser/prefix/parse-prefix-expression.ts
+++ b/packages/interpreter/src/parser/prefix/parse-prefix-expression.ts
@@ -2,18 +2,11 @@ import Parser, { PrecedenceOrder } from '..';
 import { Expression, PrefixExpression } from '../../ast';
 
 export default function parsePrefixExpression(this: Parser): Expression {
-  if (this.currToken === undefined) {
-    throw new TypeError(`Was expecting ${this.currToken} to be defined`);
-  }
-  const prefixExpression = new PrefixExpression(
+  const expr = new PrefixExpression(
     this.currToken,
     this.currToken.literal
   );
   this.nextToken();
-  let expression = this.parseExpression(PrecedenceOrder.PREFIX);
-  if (expression) {
-    prefixExpression.right = expression;
-  }
-
-  return prefixExpression;
+  expr.right = this.parseExpression(PrecedenceOrder.PREFIX);
+  return expr;
 }

--- a/packages/interpreter/src/token/index.ts
+++ b/packages/interpreter/src/token/index.ts
@@ -59,6 +59,7 @@ export type ReturnStatementToken = {
   literal: LiteralType;
 };
 export type IfExpressionToken = { type: TokenType.IF; literal: LiteralType };
+export type LeftParenToken = { type: TokenType.LPAREN; literal: LiteralType };
 export type LeftBraceToken = { type: TokenType.LBRACE; literal: LiteralType };
 export type FunctionLiteralToken = {
   type: TokenType.FUNCTION;

--- a/packages/interpreter/src/utils/assert-token-type.ts
+++ b/packages/interpreter/src/utils/assert-token-type.ts
@@ -1,7 +1,7 @@
 import { Token, TokenType, LiteralType } from '../token';
 import { AssertionError } from 'assert';
 
-export function assertTokenType<T extends TokenType>(
+export default function assertTokenType<T extends TokenType>(
   token: Token,
   ...assertedTokenTypes: T[]
 ): asserts token is { type: T; literal: LiteralType } {


### PR DESCRIPTION
- Clean up tests to use expected length vs hardcoded lengths
- Refactor AST nodes
  - Make default undefined properties null instead
  - Clean up infix/prefix parse functions to pass parsing method calls
directly to the AST node
  - Clean up imports for AST nodes
- Refactor Parser and infix/prefix parse functions
  - Use definite assignment (!:) in the Parser class to denote that
`currToken` and `peekToken` will never be undefined. We call
`nextToken()` twice when the Parser is initialized to set `currToken`
and `peekToken` to the first two tokens the Lexer encounters
  - Remove now unnecessary checks for undefined/null when accessing
`currToken` and `peekToken`
  - Make most Parser methods public (they were only private by chance)
  - Reorder Parser methods
  - Rename assertions util to assert-token-type